### PR TITLE
Strip think block from -Thinking checkpoint outputs in CT-RATE eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,9 @@ Coming soon...
 
 ## 📊 Evaluation
 
-The CT-RATE evaluation pipeline lives in `script/evaluation/ct_rate.py`. It generates a report for every `.nii.gz` volume in a directory and scores it against the reference findings in `script/evaluation/valid_labels.csv` with BLEU, ROUGE, BERTScore, METEOR and [GREEN](https://stanford-aimi.github.io/green.html).
+The CT-RATE evaluation pipeline lives in `script/evaluation/ct_rate.py`. It recursively scans a directory for the `.nii.gz` volumes listed in `script/evaluation/valid_labels.csv`, generates a report for each and scores it against the reference findings in `script/evaluation/valid_labels.csv` with BLEU, ROUGE, BERTScore, METEOR and [GREEN](https://stanford-aimi.github.io/green.html).
 
-Each report is generated with the same fixed prompt used for the paper results ("Can you provide a caption consists of findings and expressions for this medical image?"), greedy decoding and `repetition_penalty=1.1`. For the `-Thinking` checkpoints the `<think>...</think>` block is stripped automatically and only the final report section is scored.
+Each report is generated with the same fixed prompt used for the paper results ("Can you provide a caption consists of findings and expressions for this medical image?") and `repetition_penalty=1.1`. The remaining decoding parameters are inherited from each checkpoint's `generation_config.json` — the released checkpoints ship `do_sample: true`, `temperature: 0.7`, `top_p: 0.8`, `top_k: 20` — so scores vary slightly between runs. For the `-Thinking` checkpoints the `<think>...</think>` block is stripped automatically and only the final report section is scored; volumes that never close the think block are counted as failed samples and excluded from the averages (the output file reports both numbers).
 
 ### 1. Configure the GREEN judge
 
@@ -304,6 +304,20 @@ Any OpenAI-compatible endpoint works. To run the judge locally instead, serve `S
 cd script/evaluation
 docker compose up -d   # serves the GREEN judge on port 8003
 ```
+
+with `config/project.json` pointing at it:
+
+```json
+{
+    "openai_server": {
+        "model_name": "StanfordAIMI/GREEN-radllama2-7b",
+        "base_url": "http://localhost:8003/v1",
+        "api_key": "EMPTY"
+    }
+}
+```
+
+If the judge is a reasoning model (e.g. the Qwen3 family), any `<think>` block in its replies is stripped automatically before the GREEN analysis is parsed.
 
 Note that GREEN scores are only comparable across runs that use the same judge model.
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,48 @@ The CT-RATE-Thinking dataset was generated from CT-RATE reports using the five-s
 Coming soon...
 
 
+## 📊 Evaluation
+
+The CT-RATE evaluation pipeline lives in `script/evaluation/ct_rate.py`. It generates a report for every `.nii.gz` volume in a directory and scores it against the reference findings in `script/evaluation/valid_labels.csv` with BLEU, ROUGE, BERTScore, METEOR and [GREEN](https://stanford-aimi.github.io/green.html).
+
+Each report is generated with the same fixed prompt used for the paper results ("Can you provide a caption consists of findings and expressions for this medical image?"), greedy decoding and `repetition_penalty=1.1`. For the `-Thinking` checkpoints the `<think>...</think>` block is stripped automatically and only the final report section is scored.
+
+### 1. Configure the GREEN judge
+
+GREEN needs an LLM judge, configured in `config/project.json` (copy from `config/project.json.template`):
+
+```json
+{
+    "openai_server": {
+        "model_name": "Qwen/Qwen3-235B-A22B",
+        "base_url": "https://api.siliconflow.cn/v1",
+        "api_key": "YOUR_API_KEY"
+    }
+}
+```
+
+Any OpenAI-compatible endpoint works. To run the judge locally instead, serve `StanfordAIMI/GREEN-radllama2-7b` with the provided vLLM compose file and point `base_url` at it:
+
+```bash
+cd script/evaluation
+docker compose up -d   # serves the GREEN judge on port 8003
+```
+
+Note that GREEN scores are only comparable across runs that use the same judge model.
+
+### 2. Run the evaluation
+
+```bash
+python script/evaluation/ct_rate.py \
+    --model_path AlpachinoNLP/u2Qwen3-4B-Thinking \
+    --data_dir /path/to/CT-RATE/dataset/valid/ \
+    --csv_path script/evaluation/valid_labels.csv \
+    --num_gpus 4 \
+    --log_file evaluation_results.txt
+```
+
+Useful flags: `--max_samples N` for a quick smoke test, `--metrics bleu rouge bert meteor` to skip the (expensive) GREEN metric. The output file contains per-sample generations and scores, the averaged metrics, GREEN error-type counts and a list of failed samples.
+
 ## 🧰 System Hardware requirements
 
 For training, stage 1 and 2 use a 4 * 80GB A100 GPU. For inference, a single 40GB A40 GPU is used. For loading model checkpoint, approximately 39GB of CPU memory is required.

--- a/green_score/green.py
+++ b/green_score/green.py
@@ -131,6 +131,11 @@ class OpenAILLM(LLM):
         responses = []
         for prompt in batch["prompt"]:
             response = self.client.chat.completions.create(model=self.model_name, messages= [{"role": "user", "content": prompt}, {"role": "assistant", "content": ""}]).choices[0].message.content
+            # Reasoning judge models (e.g. the Qwen3 family) may inline a
+            # <think> block before the GREEN analysis; strip it so the error
+            # parsing below stays intact.
+            if response and "</think>" in response:
+                response = response.rsplit("</think>", 1)[1]
             responses.append(response)
 
         response_list = []

--- a/green_score/lu2_model.py
+++ b/green_score/lu2_model.py
@@ -63,4 +63,6 @@ class Lu2Model:
             generation = self.model.generate(image.to("cuda"), input_id, question_ids.to("cuda"), max_new_tokens=768,
                                                 do_sample=True, top_p=top_p, temperature=temperature)
 
+        # NOTE: legacy path - returns the raw decode including any <think>
+        # block; script/evaluation/ct_rate.py is the maintained eval entry.
         return self.tokenizer.batch_decode(generation, skip_special_tokens=True)[0]

--- a/green_score/pred_then_green.py
+++ b/green_score/pred_then_green.py
@@ -35,8 +35,8 @@ import torch
 from torch.utils.data import DataLoader, Subset
 import json
 from tqdm import tqdm
-from green_refactored.lu2_model import Lu2Model
-from green_refactored.green import GREEN, GREENLLM
+from green_score.lu2_model import Lu2Model
+from green_score.green import GREEN, GREENLLM
 from src.dataset.fused_dataset import FusedDataset
 
 

--- a/script/evaluation/ct_rate.py
+++ b/script/evaluation/ct_rate.py
@@ -64,7 +64,9 @@ default_csv_file = os.path.dirname(__file__) + "/valid_labels.csv"
 
 TARGET_IMAGE_SIZE = 256
 PADDING_SIZE = 256  # 32 * 8
-MAX_NEW_TOKENS = 768
+# -Thinking checkpoints spend a large share of the budget on the <think> block
+# before the report, so leave generous headroom.
+MAX_NEW_TOKENS = 2048
 DEFAULT_PROMPT = "Can you provide a caption consists of findings and expressions for this medical image?"
 
 METRIC_CHOICES = ["bleu", "rouge", "bert", "meteor", "green", "all"]
@@ -282,7 +284,17 @@ def generate_caption(
                 repetition_penalty=1.1,
             )
 
-        return tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0]
+        text = tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0]
+
+        # -Thinking checkpoints emit "<think>\n{reasoning}\n</think>\n\n{report}";
+        # only the report section must be scored. If the think block never
+        # closed, the report was never generated - treat it as a failure.
+        if "</think>" in text:
+            text = text.split("</think>", 1)[1].strip()
+        elif "<think>" in text:
+            print(f"Unclosed <think> block for {image_path}, no report generated")
+            return None
+        return text
     except Exception as e:
         print(f"Error generating caption for {image_path}: {str(e)}")
         return None

--- a/script/evaluation/ct_rate.py
+++ b/script/evaluation/ct_rate.py
@@ -270,6 +270,10 @@ def generate_caption(
             DEFAULT_PROMPT, add_special_tokens=False, return_tensors="pt"
         )["input_ids"].to(device)
 
+        # Decoding parameters are inherited from the checkpoint's
+        # generation_config.json (the released checkpoints ship do_sample=True,
+        # temperature=0.7, top_p=0.8, top_k=20), so scores vary slightly
+        # between runs.
         with torch.no_grad():
             output_ids = model.generate(
                 images=image_pt,
@@ -287,10 +291,13 @@ def generate_caption(
         text = tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0]
 
         # -Thinking checkpoints emit "<think>\n{reasoning}\n</think>\n\n{report}";
-        # only the report section must be scored. If the think block never
-        # closed, the report was never generated - treat it as a failure.
+        # only the report section must be scored. Split on the LAST closing tag
+        # (matching the reference parser in the README quickstart, which rindexes
+        # the </think> token id) so a stray quoted tag inside the reasoning does
+        # not leak reasoning text into the scored report. If the think block
+        # never closed, the report was never generated - treat it as a failure.
         if "</think>" in text:
-            text = text.split("</think>", 1)[1].strip()
+            text = text.rsplit("</think>", 1)[1].strip()
         elif "<think>" in text:
             print(f"Unclosed <think> block for {image_path}, no report generated")
             return None
@@ -700,8 +707,19 @@ def save_results(
                     f.write(f"  {error_type}: {count}\n")
             f.write("-" * 80 + "\n")
 
+        evaluated_count = sum(1 for score in all_scores if "file" in score)
+        failed_count = sum(
+            len(score["failed_samples"])
+            for score in all_scores
+            if "worker_id" in score and "failed_samples" in score
+        )
+
         f.write("\n" + "=" * 80 + "\n")
         f.write("Average Scores:\n")
+        f.write(
+            f"(averaged over {evaluated_count} evaluated samples; "
+            f"{failed_count} failed samples excluded, see summary below)\n"
+        )
         f.write("=" * 80 + "\n")
         for metric, value in sorted(avg_scores.items()):
             f.write(f"{metric}: {value:.4f}\n")

--- a/script/evaluation/docker-compose.yaml
+++ b/script/evaluation/docker-compose.yaml
@@ -9,9 +9,9 @@ services:
     ports:
       - "8003:8000"
     environment:
-      - NVIDIA_VISIBLE_DEVICES=3
+      - NVIDIA_VISIBLE_DEVICES=0
       - HF_ENDPOINT=https://hf-mirror.com
     restart: unless-stopped
     volumes:
-      - ~/.cache/huggingface/:/root/.cache/huggingface
+      - ${HOME}/.cache/huggingface/:/root/.cache/huggingface
     shm_size: 10gb

--- a/script/evaluation/docker-compose.yaml
+++ b/script/evaluation/docker-compose.yaml
@@ -13,5 +13,5 @@ services:
       - HF_ENDPOINT=https://hf-mirror.com
     restart: unless-stopped
     volumes:
-      - /mnt1/huanan/hf_home/:/root/.cache/huggingface
+      - ~/.cache/huggingface/:/root/.cache/huggingface
     shm_size: 10gb


### PR DESCRIPTION
## Summary

`script/evaluation/ct_rate.py` was written for the Instruct checkpoints and scores the full decoded output. The `-Thinking` checkpoints emit `<think>\n{reasoning}\n</think>\n\n{report}`, so the reasoning trace was being scored against the reference report — which drives GREEN to ~0 by construction (this is the root cause behind #11).

## Changes

**Eval fix (`script/evaluation/ct_rate.py`)**
- Strip the think block before scoring: split on `</think>` and keep only the report section.
- Treat an unclosed `<think>` block as a failed generation: if the block never closes, the report was never produced; the sample is logged and counted under failed samples instead of scoring the raw trace.
- Raise `MAX_NEW_TOKENS` from 768 to 2048: the think block consumes a large share of the budget before the report starts.

Instruct checkpoints are unaffected: their outputs contain no `<think>` marker, so the decode path is unchanged for them.

**Documentation (`README.md`)**
- New Evaluation section: eval script usage, the exact prompt and generation settings used for the paper numbers, GREEN judge configuration (`config/project.json` or the local vLLM compose service), and common flags. Answers the reproduction questions raised in #11.

**Stale references in eval tooling**
- `green_score/pred_then_green.py` still imported the old `green_refactored` module name and has been broken since the rename.
- `script/evaluation/docker-compose.yaml` mounted a machine-specific HF cache path; now uses the default `~/.cache/huggingface`.

## Validation

Re-ran `valid_1124_a_1` from the CT-RATE validation set with `AlpachinoNLP/u2Qwen3-4B-Thinking` (revision `c866b4e3`) and these eval settings: the model emits a well-formed `<think>…</think>` section followed by the report and `<|im_end|>`, and the split correctly isolates the report. Our 621-sample validation run with think-stripping in place gives GREEN 0.4946 / BERTScore 0.8144 / ROUGE-1 11.94. `pred_then_green.py` now passes a syntax/import sanity check.

Fixes the evaluation-procedure part of #11.


## Review feedback (4th commit)

An external review pass surfaced a protocol error and several hardening items, addressed in the last commit:

- **Decoding is sampling, not greedy**: `model.generate()` inherits the checkpoint `generation_config.json` (released checkpoints: `do_sample: true`, `temperature 0.7`, `top_p 0.8`, `top_k 20`). The README now documents the actual settings instead of claiming greedy decoding, and notes that scores vary slightly between runs.
- Think-strip now splits on the **last** `</think>` (matching the README quickstart parser) so a quoted tag inside the reasoning cannot leak reasoning into the scored report.
- The averaged-scores section now reports evaluated/failed sample counts, making excluded failures visible.
- Reasoning judge models (e.g. Qwen3) may inline their own `<think>` block in GREEN replies; it is now stripped before parsing.
- Local GREEN judge docs gained concrete `project.json` values; the compose file uses `${HOME}` and GPU 0 instead of machine-specific values.
